### PR TITLE
Explicitly exit tag_cloud_search asap if we're not doing a search

### DIFF
--- a/tag_cloud/tag_cloud_search.js
+++ b/tag_cloud/tag_cloud_search.js
@@ -1,5 +1,9 @@
 ( function(w, $) {
   w.search_tag = function () {
+    if (window.location.hash == '') {
+      // console.log("empty hash");
+      return;
+    }
     var params = window.location.hash.split(',');
     var search_term = params[0].replace('#','');
     var search_id = parseInt(params[1]) - 1;


### PR DESCRIPTION
* we were seeing some errors about .offset() not being defined, due to not finding any results